### PR TITLE
Bump version to 0.10.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: restic
 base: core18
-version: "0.9.6"
+version: "0.10.0"
 # https://github.com/snapcore/snapd/blob/master/spdx/licenses.go
 license: "BSD-2-Clause"
 summary: Fast, secure, efficient backup program.


### PR DESCRIPTION
Bump version to 0.10.0 to keep sync with upstream.

I've built, tested and run the snap locally with the new version and it seems to work without any problems.